### PR TITLE
Changing backend to `python-sixel`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ classifiers = [
     "Framework :: Matplotlib",
     "Topic :: Terminals",
 ]
-dependencies = [ "matplotlib" ]
+dependencies = [ "matplotlib", "sixel" ]
 
 [project.urls]
 "Homepage" = "https://github.com/ctorney/matplotlib-backend-sixel"


### PR DESCRIPTION
Changing the backend to [`python-sixel`](https://pypi.org/project/sixel/). 

As `python-sixel` is self-contained, the installation can now be done simply by `pip install matplotlib-backend-sixel`, without the need for `imagemagick` or `libsixel` to be installed on the user's system.

![Screenshot_20240924_134133](https://github.com/user-attachments/assets/71dff1e9-db06-4bcb-8821-3b0d0d9e591d)
